### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/annomathtex/annomathtex/recommendation/formula_concept_db_handler.py
+++ b/annomathtex/annomathtex/recommendation/formula_concept_db_handler.py
@@ -1,5 +1,5 @@
 from ..views.helper_classes.data_repo_handler import DataRepoHandler
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 class FormulaConceptDBHandler(object):

--- a/annomathtex/annomathtex/recommendation/static_wikidata_handler.py
+++ b/annomathtex/annomathtex/recommendation/static_wikidata_handler.py
@@ -5,7 +5,7 @@ from ..config import recommendations_limit
 from ..settings.common import PROJECT_ROOT
 from ..parsing.mathhandling.custom_math_env_parser import CustomMathEnvParser
 from ..views.helper_classes.data_repo_handler import DataRepoHandler
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from operator import itemgetter
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fuzzywuzzy==0.17.0
+rapidfuzz==0.9.1
 nltk==3.4.5
 SPARQLWrapper==1.8.2
 html2text==2018.1.9


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy